### PR TITLE
Convert URL-like text to links in plugins readme

### DIFF
--- a/public/app/features/plugins/plugin_edit_ctrl.ts
+++ b/public/app/features/plugins/plugin_edit_ctrl.ts
@@ -97,7 +97,9 @@ export class PluginEditCtrl {
 
   initReadme() {
     return this.backendSrv.get(`/api/plugins/${this.pluginId}/markdown/readme`).then(res => {
-      var md = new Remarkable();
+      var md = new Remarkable({
+        linkify: true
+      });
       this.readmeHtml = this.$sce.trustAsHtml(md.render(res));
     });
   }


### PR DESCRIPTION
In the simple-json-datasource plugin edit page open on the readme tab, the URL-like texts are not converted to links. The current pull request sets the `linkify` configuration option to true for `Remarkable` in order to auto convert URL to links.

See https://github.com/jonschlinkert/remarkable#constructor

![capture du 2018-08-08 15-52-18](https://user-images.githubusercontent.com/319774/43841386-5ab9962a-9b23-11e8-88ba-b30bae99b12f.png)
